### PR TITLE
changed (ad-do-it) to ad-do-it

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -356,8 +356,7 @@ SYNTAX-GUESS is the output of `c-guess-basic-syntax'."
     (setq ad-return-value nil)))
 
 (defadvice c-search-decl-header-end (around dart-search-decl-header-end activate)
-  (if (not (c-major-mode-is 'dart-mode))
-      (ad-do-it)
+  (if (not (c-major-mode-is 'dart-mode)) ad-do-it
     (let ((base (point)))
       (while (and
               (c-syntactic-re-search-forward "[;{=:]" nil 'move t t)
@@ -372,7 +371,7 @@ SYNTAX-GUESS is the output of `c-guess-basic-syntax'."
         (setq base (point)))))))
 
 (defadvice c-parse-state (around dart-c-parse-state activate)
-  (if (not (c-major-mode-is 'dart-mode)) (ad-do-it)
+  (if (not (c-major-mode-is 'dart-mode)) ad-do-it
     ;; c-parse-state is a wrapper around c-parse-state-1 that does some tricks
     ;; to ensure that dangling brackets in preprocessor commands don't screw up
     ;; parse information for the real world. In Dart, all "preprocessor"


### PR DESCRIPTION
Looks like that is an error. Feel free to submit a pull request to fix this.

On Tue, Apr 23, 2013 at 5:38 AM, Daniel Davidson <> wrote:
Hi Nathan,

I just wanted to draw your attention to this issue:
http://stackoverflow.com/questions/16155013/how-to-use-dart-mode-and-d-mode-together-why-cant-we-all-get-along

There are two places in the code (line 360 and 375) that have '(ad-do-it)'. I'm not really
a lisp programmer, but one of the responders mentioned it is not a function and those parens
are not necessary. The issue I see is if I'm editing D code in d-mode that code is failing, so
for me removing those parens helped.

Thanks
Dan
