### PR TITLE
Make version check work in Emacs 25.

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -59,10 +59,10 @@
     (require 'cl)))
 
 (eval-and-compile
-  (if (and (= emacs-major-version 24) (>= emacs-minor-version 4))
+  (if (version<= "24.4" emacs-version)
     (require 'cl)))
 
-(if (and (= emacs-major-version 24) (< emacs-minor-version 3))
+(if (version< emacs-version "24.3")
     (unless (fboundp 'cl-set-difference)
       (defalias 'cl-set-difference 'set-difference)))
 


### PR DESCRIPTION
Use the version comparison functions for a more future-proof version
check.  While there, also replace the other version comparison by a
similar test.
