### PR TITLE
Add workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=18845

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -80,6 +80,10 @@
 
 (require 'cc-mode)
 (eval-when-compile
+  (and (= emacs-major-version 24)
+       (>= emacs-minor-version 4)
+       (null emacs-repository-version)
+       (require 'cl))
   (require 'cc-langs)
   (require 'cc-fonts))
 


### PR DESCRIPTION
I’ve unfortunately removed a similar workaround in
https://github.com/nex3/dart-mode/commit/bd0820825f78e805d498dcb4ecdec0783be57f94.
This is the same workaround as suggested for
https://github.com/google/protobuf/issues/295 by @opoplawski.