### PR TITLE
Explicitly load compile.el so that the compilation-error-regexp-* var…

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -90,6 +90,7 @@
 (eval-and-compile (c-add-language 'dart-mode 'java-mode))
 
 (require 'cl-lib)
+(require 'compile)
 (require 'dash)
 (require 'flycheck)
 (require 'json)


### PR DESCRIPTION
…iables are defined

This fixes compiler warnings about these variables.