### PR TITLE
Another attempt at fixing byte compilation.

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -82,7 +82,6 @@
 (eval-when-compile
   (and (= emacs-major-version 24)
        (>= emacs-minor-version 4)
-       (null emacs-repository-version)
        (require 'cl))
   (require 'cc-langs)
   (require 'cc-fonts))


### PR DESCRIPTION
Unfortunately ‘emacs-repository-version’ is not defined in Emacs 24.3, so byte
compilation fails on that version.  Just remove the test entirely, it should
not change the semantics, as the issue with the missing ‘cl’ library should be
present no matter whether it’s nil or not.