### PR TITLE
push marker stack before jump on dart-goto

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -1202,6 +1202,10 @@ minibuffer."
 (defun dart-goto ()
   (interactive)
   (-when-let (filename (buffer-file-name))
+    (if (fboundp 'xref-push-marker-stack)
+        (xref-push-marker-stack)
+      (with-no-warnings
+        (ring-insert find-tag-marker-ring (point-marker))))
     (dart--analysis-server-send
      "analysis.getNavigation"
      `(("file" . ,filename) ("offset" . ,(point)) ("length" . 0))


### PR DESCRIPTION
Implement pushing current marker position into the marker stack before moving file.

So users easily jump back by pop marker function (normally binded `M-,`)

Most similar functions in other language modes have the same feature. (ex: `godef-jump` in go-mode.el, `racer-find-definition` in racer.el, `tide-jump-to-definition` in tide.el) 
I'm heavily depending on this feature, so be very happy if dart-mode might do this too.
