### PR TITLE
Hack to fontify single quoted strings

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -423,6 +423,11 @@ Returns nil if `dart-sdk-path' is nil."
 (c-lang-defconst c-opt-postfix-decl-spec-kwds
   dart '("native"))
 
+(c-lang-defconst c-before-font-lock-functions
+  dart '(c-depropertize-new-text
+	       c-restore-<>-properties
+	       c-change-expand-fl-region))
+
 (push '(dart-brace-list-cont-nonempty . 0)
       (get 'c-offsets-alist 'c-stylevar-fallback))
 


### PR DESCRIPTION
With @ahungry's hint in issue #47, that problem is with `c-parse-quotes-after-change`, I found a block in `lisp/progmodes/cc-langs.el` that suggested the changes in this commit. I believe this change provides syntax highlighting of single quoted strings.