### PR TITLE
Removes nil c-syntactic-context

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -456,9 +456,6 @@ Returns nil if `dart-sdk-path' is nil."
 
 ;;; CC indentation support
 
-(defvar c-syntactic-context nil
-  "A dynamically-bound variable used by cc-mode.")
-
 (defun dart-block-offset (info)
   "Calculate the correct indentation for inline functions.
 


### PR DESCRIPTION
This commit removes `nil`ing `c-syntactic-context` completely, if this causes problems, maybe it can be `setq-default` in `defun dart-mode` block, so it doesn't affect editing code in other cc modes. Having this non-`nil` may be useful for exploring cc with `C-c C-s` as per the manual suggests, considering if improving assignment of syntactic symbols somehow, as suggested at `(ccmode) Syntactic Symbols`.

Regrading issue #53.