### PR TITLE
Removes cc-mode

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -78,19 +78,13 @@
 
 ;;; Code:
 
-(require 'cc-mode)
-(eval-when-compile
-  (require 'cc-langs)
-  (require 'cc-fonts))
-
-(eval-and-compile (c-add-language 'dart-mode 'java-mode))
-
 (require 'cl-lib)
 (require 'compile)
 (require 'dash)
 (ignore-errors
  (require 'flycheck))
 (require 'json)
+(require 'rx)
 (require 's)
 
 
@@ -277,172 +271,7 @@ Returns nil if `dart-sdk-path' is nil."
 
 ;;; CC configuration
 
-(c-lang-defconst c-symbol-start
-  dart (concat "[" c-alpha "_]"))
-
-(c-lang-defconst c-identifier-ops
-  dart nil)
-
-(c-lang-defconst c-after-id-concat-ops
-  dart nil)
-
-(c-lang-defconst c-multiline-string-start-char
-  dart ?@)
-
-(c-lang-defconst c-opt-cpp-prefix
-  dart "\\s *#\\s *")
-
-(c-lang-defconst c-cpp-message-directives
-  dart nil)
-
-(c-lang-defconst c-cpp-include-directives
-  dart nil)
-
-(c-lang-defconst c-opt-cpp-macro-define
-  dart nil)
-
-(c-lang-defconst c-cpp-expr-directives
-  dart '("import" "source" "library" "resource"))
-
-(c-lang-defconst c-cpp-expr-functions
-  dart nil)
-
-(c-lang-defconst c-operators
-  dart `((prefix "#")
-         (postfix-if-paren "<" ">")
-         (prefix "super")
-         (left-assoc ".")
-         (postfix "++" "--" "[" "]" "(" ")")
-         (unary "++" "--" "+" "-" "!" "~" "negate" "new" "const")
-         (left-assoc "*" "/" "%")
-         (left-assoc "+" "-")
-         (left-assoc "<<" ">>" ">>>")
-         (left-assoc "<" ">" "<=" ">=")
-         (left-assoc "==" "!=" "===" "!==" "is" "is!")
-         (left-assoc "&")
-         (left-assoc "^")
-         (left-assoc "|")
-         (left-assoc "&&")
-         (left-assoc "||")
-         (right-assoc-sequence "?" ":")
-         (left-assoc "=>")
-         (right-assoc ,@(c-lang-const c-assignment-operators))
-         (left-assoc ",")))
-
-(c-lang-defconst c-overloadable-operators
-  dart '("==" "<" ">" "<=" ">=" "-" "+" "*" "/" "%" "|" "^" "&"
-         "<<" ">>" ">>>" "[]=" "[]" "~" "negate"))
-
-(c-lang-defconst c-opt-op-identifier-prefix
-  dart (c-make-keywords-re t '("operator")))
-
-(c-lang-defconst c-doc-comment-start-regexp
-  dart nil)
-
-(c-lang-defconst c-paragraph-start
-  dart "$")
-
-(c-lang-defconst c-primitive-type-kwds
-  dart '("Dynamic" "void" "num" "int" "double" "bool"))
-
-(c-lang-defconst c-class-decl-kwds
-  dart '("class" "interface"))
-
-;; Don't put these in c-modifier-kwds because they can be used without a type
-;; following them.
-(c-lang-defconst c-typeless-decl-kwds
-  dart '("abstract" "const" "factory" "final" "operator" "static" "typedef" "var"))
-
-(c-lang-defconst c-modifier-kwds
-  dart nil)
-
-(c-lang-defconst c-other-decl-kwds
-  dart nil)
-
-(c-lang-defconst c-decl-hangon-kwds
-  dart '("get" "set" "native"))
-
-(c-lang-defconst c-postfix-decl-spec-kwds
-  dart '("extends" "implements" "factory"))
-
-(c-lang-defconst c-type-list-kwds
-  dart '("new" "const" "is" "is!" "extends" "implements" "factory"))
-
-(c-lang-defconst c-ref-list-kwds
-  dart nil)
-
-(c-lang-defconst c-block-stmt-2-kwds
-  dart '("for" "if" "switch" "while" "catch"))
-
-(c-lang-defconst c-simple-stmt-kwds
-  dart '("break" "continue" "return" "throw"))
-
-(c-lang-defconst c-before-label-kwds
-  dart '("break" "continue"))
-
-(c-lang-defconst c-nonlabel-token-key
-  dart (concat (concat "\\s\(\\|" (c-lang-const c-nonlabel-token-key))))
-
-(c-lang-defconst c-inexpr-class-kwds
-  dart nil)
-
-(c-lang-defconst c-inexpr-brace-list-kwds
-  dart nil)
-
-(c-lang-defconst c-other-kwds
-  dart '("in"))
-
-(c-lang-defconst c-decl-prefix-re
-  dart "\\([\{\}\([;,<]+\\)")
-
-(c-lang-defconst c-cast-parens
-  dart nil)
-
-(c-lang-defconst c-block-prefix-disallowed-chars
-  dart (cl-set-difference (c-lang-const c-block-prefix-disallowed-chars)
-                          '(?\" ?')))
-
-(c-lang-defconst c-type-decl-prefix-key
-  dart "\\(\(\\)\\([^=]\\|$\\)")
-
-(c-lang-defconst c-after-suffixed-type-decl-key
-  dart (concat (c-lang-const c-after-suffixed-type-decl-key) "\\|:"))
-
-(c-lang-defconst c-opt-type-suffix-key
-  dart nil)
-
-(c-lang-defconst c-recognize-typeless-decls
-  dart t)
-
-(c-lang-defconst c-recognize-<>-arglists
-  dart t)
-
-(c-lang-defconst c-opt-postfix-decl-spec-kwds
-  dart '("native"))
-
-(c-lang-defconst c-opt-postfix-decl-spec-kwds
-  dart '("native"))
-
-(push '(dart-brace-list-cont-nonempty . 0)
-      (get 'c-offsets-alist 'c-stylevar-fallback))
-
-(defconst dart-c-style
-  '("java"
-    (c-basic-offset . 2)
-    (indent-tabs-mode . nil)
-    (fill-column . 80)
-    (c-offsets-alist . ((arglist-intro . ++)
-                        (arglist-cont-nonempty . ++)
-                        (statement-block-intro . dart-block-offset)
-                        (block-close . dart-block-offset)
-                        (dart-brace-list-cont-nonempty .
-                         dart-brace-list-cont-nonempty-offset)
-                        (case-label . +))))
-  "The default Dart styles.")
-
-(c-add-style "dart" dart-c-style)
-
-(defvar dart-mode-map (c-make-inherited-keymap)
+(defvar dart-mode-map (make-sparse-keymap)
   "Keymap used in dart-mode buffers.")
 (define-key dart-mode-map (kbd "C-c ?") 'dart-show-hover)
 (define-key dart-mode-map (kbd "C-c C-g") 'dart-goto)
@@ -454,171 +283,52 @@ Returns nil if `dart-sdk-path' is nil."
 (define-key dart-mode-map (kbd "M-/") 'dart-expand)
 (define-key dart-mode-map (kbd "M-?") 'dart-expand-parameters)
 
+
 ;;; CC indentation support
 
-(defun dart-block-offset (info)
-  "Calculate the correct indentation for inline functions.
-
-When indenting inline functions, we want to pretend that
-functions taking them as parameters essentially don't exist."
-  (cl-destructuring-bind (syntax . anchor) info
-    (let ((arglist-count
-           (cl-loop for (symbol . _) in c-syntactic-context
-                    count (eq symbol 'arglist-cont-nonempty))))
-      (if (> arglist-count 0)
-          (- (* -1 c-basic-offset arglist-count)
-             (if (eq syntax 'block-close) c-basic-offset 0))
-        (if (eq syntax 'block-close) 0 '+)))))
-
-(defun dart-brace-list-cont-nonempty-offset (info)
-  "Indent a brace-list line in the same style as arglist-cont-nonempty.
-This could be either an actual brace-list or an optional parameter."
-  (cl-destructuring-bind (_ . anchor) info
-    ;; If we're in a function definition with optional arguments, indent as if
-    ;; the brace wasn't there. Currently this misses the in-function function
-    ;; definition, but that's probably acceptable.
-    (if (and
-         (save-excursion (backward-up-list) (eq (char-after) ?\[))
-         (assq 'topmost-intro
-               (save-excursion (goto-char anchor) (c-guess-basic-syntax))))
-        '++
-      ;; Otherwise, we're in an actual brace list, in which case only indent
-      ;; once.
-      '+)))
-
-(defun dart-in-block-p (syntax-guess)
-  "Return whether or not the immediately enclosing {} block is a code block.
-The other option, of course, is a map literal.
-
-SYNTAX-GUESS is the output of `c-guess-basic-syntax'."
-  (save-excursion
-    (c-safe
-      ;; If we're in a continued statement within a class, we want to know we're
-      ;; in a class so we can return true.
-      (when (eq 'statement-cont (caar syntax-guess))
-        (save-excursion
-          (c-beginning-of-statement-1 nil t t)
-          (setq syntax-guess (c-guess-basic-syntax))))
-
-      (backward-up-list)
-      (when (= (char-after) ?\{)
-        (c-backward-comments)
-        (or
-         ;; Both anonymous and named functions have a ")" immediately before the
-         ;; code block.
-         (= (char-before) ?\))
-         ;; "else" and "try" are the only keywords that come immediately before
-         ;; a block.  Look only back at most 4 characters (the length of
-         ;; "else") for performance reasons.
-         (looking-back "\\<\\(else\\|try\\)\\>" (- (point) 4))
-         ;; CC is good at figuring out if we're in a class.
-         (assq 'inclass syntax-guess))))))
-
-(defadvice c-guess-basic-syntax (after dart-guess-basic-syntax activate)
-  (when (c-major-mode-is 'dart-mode)
-    (let* ((syntax (car (last ad-return-value)))
-           (type (car syntax)))
-      (save-excursion
-        (back-to-indentation)
-
-        (or
-         ;; Handle indentation in a constructor with an initializer on a
-         ;; separate line.
-         (when (memq type '(defun-block-intro inline-close))
-           (save-excursion
-             (c-safe
-               (goto-char (cadr syntax))
-               (when (= (char-after) ?:)
-                 (c-beginning-of-statement-1)
-                 (setq ad-return-value `((,type ,(point))))
-                 t))))
-
-         ;; Handle array literal indentation
-         (when (memq type
-                     '(arglist-intro
-                       arglist-cont
-                       arglist-cont-nonempty
-                       arglist-close))
-           (save-excursion
-             (c-safe
-               (backward-up-list)
-               (when (= (char-after) ?\[)
-                 (setq ad-return-value
-                       `((,(cl-case type
-                             (arglist-intro 'brace-list-intro)
-                             (arglist-cont 'brace-list-entry)
-                             (arglist-cont-nonempty 'dart-brace-list-cont-nonempty)
-                             (arglist-close 'brace-list-close))
-                          ,(cadr syntax)))))
-               t)))
-
-         ;; Handle map literal indentation
-         (when (and (memq type '(label statement-block-intro statement-cont statement
-                                 block-close defun-block-intro defun-close))
-                    (not (dart-in-block-p ad-return-value)))
-           (save-excursion
-             (c-safe
-               (if (= (char-after) ?\})
-                   (progn
-                     (backward-up-list)
-                     (when (= (char-after) ?\{)
-                       (back-to-indentation)
-                       (setq ad-return-value `((brace-list-close ,(point))))))
-                 (c-backward-comments)
-                 ;; Completely reset ad-return-value here because otherwise it
-                 ;; gets super-screwy.
-                 (if (= (char-before) ?\{)
-                     (progn
-                       (back-to-indentation)
-                       (setq ad-return-value `((brace-list-intro ,(point))))
-                       t)
-                   (backward-up-list)
-                   (when (= (char-after) ?\{)
-                     (forward-char)
-                     (let ((contp (not (looking-at "\\s-*$"))))
-                       (c-forward-comments)
-                       (back-to-indentation)
-                       (setq ad-return-value
-                             `((,(if contp 'dart-brace-list-cont-nonempty
-                                   'brace-list-entry)
-                                ,(point))))
-                       t))))))))))))
-
-(defadvice c-inside-bracelist-p (after dart-inside-bracelist-p activate)
-  ;; This function is only called within c-guess-basic-syntax. Since we do all
-  ;; out brace-list detection in our advice, we just never report being in a
-  ;; bracelist there.
-  (when (c-major-mode-is 'dart-mode)
-    (setq ad-return-value nil)))
-
-(defadvice c-search-decl-header-end (around dart-search-decl-header-end activate)
-  (if (not (c-major-mode-is 'dart-mode)) ad-do-it
-    (let ((base (point)))
-      (while (and
-              (c-syntactic-re-search-forward "[;{=:]" nil 'move t t)
-              (c-end-of-current-token base))
-        (setq base (point)))
-      ;; If we hit :, we're in a member initialization list and we want to
-      ;; ignore = signs.
-      (when (= (char-before) ?:)
-        (while (and
-                (c-syntactic-re-search-forward "[;{]" nil 'move t t)
-                (c-end-of-current-token base))
-        (setq base (point)))))))
-
-(if (fboundp 'c-parse-state-1)
-  (defadvice c-parse-state (around dart-c-parse-state activate)
-    (if (not (c-major-mode-is 'dart-mode)) ad-do-it
-      ;; c-parse-state is a wrapper around c-parse-state-1 that does some tricks
-      ;; to ensure that dangling brackets in preprocessor commands don't screw up
-      ;; parse information for the real world. In Dart, all "preprocessor"
-      ;; directives have matched braces, so we don't need to worry about that. The
-      ;; wrapper was also screwing up indentation in weird ways, so we just ignore
-      ;; it.
-      (setq ad-return-value (c-parse-state-1)))))
+(defun dart-indent-line-function ()
+  (let (pt)
+    (save-excursion
+      (back-to-indentation)
+      (let ((depth (car (syntax-ppss))))
+        (if (= (char-syntax (char-after)) ?\))
+            (setq depth (1- depth)))
+        (indent-line-to (* depth tab-width)))
+      (setq pt (point)))
+    (when (< (point) pt)
+        (back-to-indentation))))
 
 
 ;;; Additional fontification support
+
+(setq dart--ecma-built-in-identifier
+      '("abstract" "as" "deferred" "dynamic" "export" "external"
+        "factory" "get" "implements" "import" "library" "operator"
+        "part" "set" "static" "typedef"))
+
+(setq dart--ecma-reserved-words
+      '("assert" "break" "case" "catch" "class" "const" "continue"
+        "default" "do" "else" "enum" "extends" "false" "final"
+        "finally" "for" "if" "in" "is" "new" "null" "rethrow" "return"
+        "super" "switch" "this" "throw" "true" "try" "var" "void"
+        "while" "with"))
+
+(setq dart--built-in-types '("double" "int" "num" "string"))
+
+(setq dart--ecma-number-re
+      (rx (and (one-or-more digit)
+               (zero-or-one (and "." (one-or-more digit))))))
+
+(setq dart-font-lock-keyword-re  (regexp-opt dart--ecma-reserved-words 'words))
+(setq dart-font-lock-builtin-re  (regexp-opt dart--ecma-built-in-identifier 'words))
+(setq dart-font-lock-type-re     (regexp-opt dart--built-in-types 'words))
+(setq dart-font-lock-constant-re dart--ecma-number-re)
+
+(setq dart-font-lock-defaults
+      `(((,dart-font-lock-keyword-re  . font-lock-keyword-face)
+         (,dart-font-lock-builtin-re  . font-lock-builtin-face)
+         (,dart-font-lock-type-re     . font-lock-type-face)
+         (,dart-font-lock-constant-re . font-lock-constant-face))))
 
 (defun dart-fontify-region (beg end)
   "Use fontify the region between BEG and END as Dart.
@@ -669,29 +379,6 @@ whichever comes first."
   "*List of extra types (aside from the type keywords) to recognize in DART mode.
 Each list item should be a regexp matching a single identifier."
   :group 'dart-mode)
-
-(c-override-default-keywords 'dart-font-lock-keywords)
-
-(defconst dart-font-lock-keywords-1 (c-lang-const c-matchers-1 dart)
-  "Minimal highlighting for Dart mode.")
-
-(defconst dart-font-lock-keywords-2 (c-lang-const c-matchers-2 dart)
-  "Fast normal highlighting for Dart mode.")
-
-(defconst dart-font-lock-keywords-3
-  (cons
-   '(dart-highlight-interpolation 1 font-lock-variable-name-face prepend)
-   (c-lang-const c-matchers-3 dart))
-  "Accurate normal highlighting for Dart mode.")
-
-(defvar dart-font-lock-keywords dart-font-lock-keywords-3
-  "Default expressions to highlight in Dart mode.")
-
-(defvar dart-mode-syntax-table nil
-  "Syntax table used in dart-mode buffers.")
-(unless dart-mode-syntax-table
-  (setq dart-mode-syntax-table
-        (funcall (c-lang-const c-make-mode-syntax-table dart))))
 
 
 ;;; Dart analysis server
@@ -1821,24 +1508,25 @@ This replaces references to TEMP-FILE with REAL-FILE."
 ;;;###autoload (add-to-list 'auto-mode-alist '("\\.dart\\'" . dart-mode))
 
 ;;;###autoload
-(defun dart-mode ()
+(define-derived-mode dart-mode prog-mode "Dart"
   "Major mode for editing Dart files.
 
-The hook `c-mode-common-hook' is run with no args at mode
-initialization, then `dart-mode-hook'.
+The hook `dart-mode-hook' is run with no args at mode
+initialization.
 
 Key bindings:
 \\{dart-mode-map}"
-  (interactive)
-  (kill-all-local-variables)
-  (c-initialize-cc-mode t)
-  (set-syntax-table dart-mode-syntax-table)
-  (setq major-mode 'dart-mode
-        mode-name "Dart")
-  (use-local-map dart-mode-map)
-  (c-init-language-vars dart-mode)
-  (c-common-init 'dart-mode)
-  (c-set-style "dart")
+  (modify-syntax-entry ?/ "< 12")
+  (modify-syntax-entry ?\n ">")
+  (modify-syntax-entry ?\' "\"")
+  (set (make-local-variable 'electric-indent-chars) '(?\n ?\) ?] ?}))
+  (setq comment-start "//")
+  (setq comment-end "")
+  (setq fill-column 80)
+  (setq font-lock-defaults dart-font-lock-defaults)
+  (setq indent-line-function 'dart-indent-line-function)
+  (setq indent-tabs-mode nil)
+  (setq tab-width 2)
   (when dart-enable-analysis-server
     (if (null dart-sdk-path)
         (dart-log
@@ -1848,9 +1536,7 @@ Key bindings:
   (add-hook (make-local-variable 'before-save-hook)
             (lambda () (when dart-format-on-save (dart-format))))
 
-  (run-hooks 'c-mode-common-hook)
-  (run-hooks 'dart-mode-hook)
-  (c-update-modeline))
+  )
 
 (provide 'dart-mode)
 

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -1535,9 +1535,7 @@ Key bindings:
       (dart--start-analysis-server-for-current-buffer)))
 
   (add-hook (make-local-variable 'before-save-hook)
-            (lambda () (when dart-format-on-save (dart-format))))
-
-  )
+            (lambda () (when dart-format-on-save (dart-format)))))
 
 (provide 'dart-mode)
 

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -316,7 +316,8 @@ Returns nil if `dart-sdk-path' is nil."
 (setq dart--built-in-types '("double" "int" "num" "string"))
 
 (setq dart--ecma-number-re
-      (rx (and (one-or-more digit)
+      (rx (and symbol-start
+               (one-or-more digit)
                (zero-or-one (and "." (one-or-more digit))))))
 
 (setq dart-font-lock-keyword-re  (regexp-opt dart--ecma-reserved-words 'words))


### PR DESCRIPTION
Almost everything with mention of `cc-*` or `c-*` has been removed.

The following has been changed to replace `cc-mode`.

- For `M-;` to work, `comment-start` and `comment-end` have been added.
- For `font-lock` to highlight comments and single quoted strings, the syntax table has changes at `//`, `\n`, and `'`.
- For now, only syntax highlighting of several keywords, and numbers, have been added. Highlighting of variables, functions, classes, etc, should be straightforward, perhaps after agreement on whether it's just declarations and definitions, etc. The number regex can be improved to match specification in ECMA for Dart.
- Electric indent occurs on `RET`, `)`, `]`, and `}`.
- Indentation function seems to be very simple after all. It uses `syntax-ppss` to check depth in open parentheses, then decrements depth if first non-whitespace char is a closing paren, and multiplies this by the `tab-width` (`tab-width` of course is two). Current indent-line-function behavior, together with existing `dart-formatter` should be convenient enough for users.