### PR TITLE
Remove cc

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -329,35 +329,33 @@ Returns nil if `dart-sdk-path' is nil."
 
 ;;; Additional fontification support
 
-(setq dart--ecma-built-in-identifier
+(setq dart--builtins
+      ;; ECMA 408; Section: Identifier Reference
+      ;; "Built-in identifiers"
       '("abstract" "as" "deferred" "dynamic" "export" "external"
         "factory" "get" "implements" "import" "library" "operator"
         "part" "set" "static" "typedef"))
 
-(setq dart--ecma-reserved-words
+(setq dart--keywords
+      ;; ECMA 408; Section: Reserved Words
       '("assert" "break" "case" "catch" "class" "const" "continue"
         "default" "do" "else" "enum" "extends" "false" "final"
         "finally" "for" "if" "in" "is" "new" "null" "rethrow" "return"
         "super" "switch" "this" "throw" "true" "try" "var" "void"
         "while" "with"))
 
-(setq dart--built-in-types '("double" "int" "num" "string"))
+(setq dart--types '("double" "int" "num" "string"))
 
-(setq dart--ecma-number-re
+(setq dart--number-re
       (rx (and symbol-start
                (one-or-more digit)
                (zero-or-one (and "." (one-or-more digit))))))
 
-(setq dart-font-lock-keyword-re  (regexp-opt dart--ecma-reserved-words 'words))
-(setq dart-font-lock-builtin-re  (regexp-opt dart--ecma-built-in-identifier 'words))
-(setq dart-font-lock-type-re     (regexp-opt dart--built-in-types 'words))
-(setq dart-font-lock-constant-re dart--ecma-number-re)
-
 (setq dart-font-lock-defaults
-      `(((,dart-font-lock-keyword-re  . font-lock-keyword-face)
-         (,dart-font-lock-builtin-re  . font-lock-builtin-face)
-         (,dart-font-lock-type-re     . font-lock-type-face)
-         (,dart-font-lock-constant-re . font-lock-constant-face))))
+      `((,(regexp-opt dart--keywords 'words)
+         (,(regexp-opt dart--builtins 'words) . font-lock-builtin-face)
+         (,dart--number-re                    . font-lock-constant-face)
+         (,(regexp-opt dart--types 'words)    . font-lock-type-face))))
 
 (defun dart-fontify-region (beg end)
   "Use fontify the region between BEG and END as Dart.

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -339,23 +339,58 @@ Returns nil if `dart-sdk-path' is nil."
 (setq dart--keywords
       ;; ECMA 408; Section: Reserved Words
       '("assert" "break" "case" "catch" "class" "const" "continue"
-        "default" "do" "else" "enum" "extends" "false" "final"
-        "finally" "for" "if" "in" "is" "new" "null" "rethrow" "return"
-        "super" "switch" "this" "throw" "true" "try" "var" "void"
-        "while" "with"))
+        "default" "do" "else" "enum" "extends" "final" "finally" "for"
+        "if" "in" "is" "new" "rethrow" "return" "super" "switch"
+        "this" "throw" "try" "var" "while" "with"))
 
-(setq dart--types '("double" "int" "num" "string"))
+(setq dart--types '("bool" "double" "dynamic" "int" "num" "void"))
 
-(setq dart--number-re
-      (rx (and symbol-start
-               (one-or-more digit)
-               (zero-or-one (and "." (one-or-more digit))))))
+(setq dart--constants '("false" "null" "true"))
+
+(setq dart--async-keywords-re (rx word-start
+                                  (or "async" "await" "sync" "yield")
+                                  word-end
+                                  (zero-or-one ?*)))
+
+(setq dart--number-re (rx symbol-start
+                          (zero-or-one ?-)
+                          (group (or (and (one-or-more digit)
+                                          (zero-or-one
+                                           (and ?. (one-or-more digit))))
+                                     (and ?. (one-or-more digit)))
+                                 (zero-or-one (and (or ?e ?E)
+                                                   (zero-or-one (or ?+ ?-))
+                                                   (one-or-more digit))))))
+
+(setq dart--hex-number-re (rx symbol-start
+                              (zero-or-one ?-)
+                              (group (or "0x" "0X")
+                                     (one-or-more (any (?a . ?f)
+                                                       (?A . ?F)
+                                                       digit)))))
+
+(defun dart--identifier (&optional case)
+  `(and (zero-or-one (or ?$ ?_))
+        bow
+        ,(if case
+             case
+           'alnum)
+        (zero-or-more (or ?$ ?_ alnum))))
+
+(setq dart--metadata-re (rx ?@ (eval (dart--identifier))))
+
+(setq dart--types-re (rx (eval (dart--identifier 'upper))))
 
 (setq dart-font-lock-defaults
-      `((,(regexp-opt dart--keywords 'words)
-         (,(regexp-opt dart--builtins 'words) . font-lock-builtin-face)
-         (,dart--number-re                    . font-lock-constant-face)
-         (,(regexp-opt dart--types 'words)    . font-lock-type-face))))
+      `((,dart--async-keywords-re
+         ,(regexp-opt dart--keywords 'words)
+         (,(regexp-opt dart--builtins 'words)  . font-lock-builtin-face)
+         (,(regexp-opt dart--constants 'words) . font-lock-constant-face)
+         (,dart--hex-number-re                 . (1 font-lock-constant-face))
+         (,dart--number-re                     . (1 font-lock-constant-face))
+         (,dart--metadata-re                   . font-lock-constant-face)
+         (,(regexp-opt dart--types 'words)     . font-lock-type-face)
+         (,dart--types-re                      . font-lock-type-face))))
 
 (defun dart-fontify-region (beg end)
   "Use fontify the region between BEG and END as Dart.

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -286,17 +286,45 @@ Returns nil if `dart-sdk-path' is nil."
 
 ;;; CC indentation support
 
-(defun dart-indent-line-function ()
-  (let (pt)
-    (save-excursion
-      (back-to-indentation)
-      (let ((depth (car (syntax-ppss))))
-        (if (= (char-syntax (char-after)) ?\))
+(defun dart-depth-of-line ()
+  (save-excursion
+    (back-to-indentation)
+    (let ((depth (car (syntax-ppss))))
+      (when (and (char-after)
+                 (= (char-syntax (char-after)) ?\x29))
+        (while (and (char-after)
+                    (/= (char-syntax (char-after)) ?\x28)
+                    (/= (char-after) ?\C-j))
+          (when (= (char-syntax (char-after)) ?\x29)
             (setq depth (1- depth)))
-        (indent-line-to (* depth tab-width)))
-      (setq pt (point)))
-    (when (< (point) pt)
-        (back-to-indentation))))
+          (forward-char)))
+      depth)))
+
+(defun dart-indent-line-function ()
+  (let ((curr-depth (dart-depth-of-line))
+        prev-line
+        prev-depth
+        prev-indent)
+    (save-excursion
+      (beginning-of-line)
+      (catch 'done
+        (while t
+          (when (= (point) 1)
+            (throw 'done t))
+          (previous-line)
+          (unless (looking-at (rx (and bol (zero-or-more space) eol)))
+            (setq prev-line t)
+            (setq prev-indent (current-indentation))
+            (setq prev-depth (dart-depth-of-line))
+            (throw 'done t)))))
+    (save-excursion
+      (if prev-line
+          (indent-line-to (max 0 (+ prev-indent
+                                    (* (- curr-depth prev-depth)
+                                       tab-width))))
+        (indent-line-to 0)))
+    (when (< (current-column) (current-indentation))
+      (back-to-indentation))))
 
 
 ;;; Additional fontification support

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -1517,7 +1517,7 @@ initialization.
 
 Key bindings:
 \\{dart-mode-map}"
-  (modify-syntax-entry ?/ "< 12")
+  (modify-syntax-entry ?/ "_ 12")
   (modify-syntax-entry ?\n ">")
   (modify-syntax-entry ?\' "\"")
   (set (make-local-variable 'electric-indent-chars) '(?\n ?\) ?] ?}))

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -1520,7 +1520,7 @@ Key bindings:
   (modify-syntax-entry ?/ "_ 12")
   (modify-syntax-entry ?\n ">")
   (modify-syntax-entry ?\' "\"")
-  (set (make-local-variable 'electric-indent-chars) '(?\n ?\) ?] ?}))
+  (setq-local electric-indent-chars '(?\n ?\x28 ?\x5d ?\x7d))
   (setq comment-start "//")
   (setq comment-end "")
   (setq fill-column 80)

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -381,6 +381,22 @@ Returns nil if `dart-sdk-path' is nil."
 
 (setq dart--types-re (rx (eval (dart--identifier 'upper))))
 
+(defun dart--function-declaration-func (limit)
+  (catch 'result
+    (let (beg end)
+      (while (re-search-forward
+              (rx (group (eval (dart--identifier 'lower))) ?\x28) limit t)
+        (setq beg (match-beginning 1))
+        (setq end (match-end 1))
+        (up-list)
+        (when (looking-at (rx (one-or-more space)
+                              (or "async" "async*" "sync*" "{" "=>")))
+          (set-match-data (list beg end))
+          (goto-char end)
+          (throw 'result t))
+        (goto-char end))
+      (throw 'result nil))))
+
 (setq dart-font-lock-defaults
       `((,dart--async-keywords-re
          ,(regexp-opt dart--keywords 'words)
@@ -390,7 +406,8 @@ Returns nil if `dart-sdk-path' is nil."
          (,dart--number-re                     . (1 font-lock-constant-face))
          (,dart--metadata-re                   . font-lock-constant-face)
          (,(regexp-opt dart--types 'words)     . font-lock-type-face)
-         (,dart--types-re                      . font-lock-type-face))))
+         (,dart--types-re                      . font-lock-type-face)
+         (dart--function-declaration-func      . font-lock-function-name-face))))
 
 (defun dart-fontify-region (beg end)
   "Use fontify the region between BEG and END as Dart.

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -423,6 +423,52 @@ Returns nil if `dart-sdk-path' is nil."
         (goto-char (match-end 1)))
       (throw 'result nil))))
 
+(defun dart--in-parenthesized-expression-or-formal-parameter-list-p ()
+  (save-excursion
+    (catch 'result
+      (condition-case nil
+          (backward-up-list)
+        (scan-error (throw 'result nil)))
+      (when (member (char-after (point)) '(?\x5b ?\x7b)) ; ?[ ?{
+        (condition-case nil
+            (backward-up-list)
+          (scan-error (throw 'result nil))))
+      (throw 'result (= (char-after (point)) ?\x28))))) ; ?\(
+
+(defun dart--declared-identifier-anchor-func (limit)
+  (catch 'result
+    (let (data)
+      (while (dart--declared-identifier-func limit)
+        (setq data (match-data))
+        (unless (dart--in-parenthesized-expression-or-formal-parameter-list-p)
+          (set-match-data data)
+          (goto-char (match-end 0))
+          (throw 'result t))
+        (goto-char (match-end 0)))
+      (throw 'result nil))))
+
+(defun dart--declared-identifier-next-func (limit)
+  (catch 'result
+    (let ((depth (car (syntax-ppss))))
+      (while t
+        (cond
+         ((or (= (char-after (point)) ?\x3b) ; ?;
+              (< (car (syntax-ppss)) depth))
+          (throw 'result nil))
+         ((and (= (char-after (point)) ?\x2c) ; ?,
+               (= (car (syntax-ppss)) depth))
+          (if (looking-at (rx ?\x2c
+                              (one-or-more space)
+                              (group (eval (dart--identifier 'lower)))))
+              (progn (set-match-data (list (match-beginning 1)
+                                           (match-end 1)))
+                     (goto-char (match-end 0))
+                     (throw 'result t))
+            (throw 'result nil)))
+         ((< (point) (point-max))
+          (forward-char))
+         (t (throw 'result nil)))))))
+
 (setq dart-font-lock-defaults
       `((,dart--async-keywords-re
          ,(regexp-opt dart--keywords 'words)
@@ -434,7 +480,12 @@ Returns nil if `dart-sdk-path' is nil."
          (,(regexp-opt dart--types 'words)     . font-lock-type-face)
          (,dart--types-re                      . font-lock-type-face)
          (dart--function-declaration-func      . font-lock-function-name-face)
-         (dart--declared-identifier-func       . font-lock-variable-name-face))))
+         (dart--declared-identifier-func       . font-lock-variable-name-face)
+         (dart--declared-identifier-anchor-func
+          . (dart--declared-identifier-next-func
+             nil
+             nil
+             (0 font-lock-variable-name-face))))))
 
 (defun dart-fontify-region (beg end)
   "Use fontify the region between BEG and END as Dart.


### PR DESCRIPTION
A few minor fixes, a little improvement in indent line function, and more fontification.

There was a misunderstanding in how we call `modify-syntax-entry` for `//` comments, we should have used `_ 12`, not `< 12`. The latter made lines like `int n = 2 / 3;` treat characters starting from `/` fontify as a comment. By itself, `/` should have symbol syntax.

`electric-indent-chars` expression is cleaner with `setq-local`. Replaced for example `?\)` with `?\x28`, hex representation, to avoid errors in evaluating buffer as elisp.

Indentation is slightly improved. It is now relative to previous line, rather than a calculation absolute to buffer. And it handle lines with multiple characters of paren syntax. I have some thoughts about challenges and directions for improving indentation function further, but don't want to bog down this particular message.

The names of `font-lock` variables were simplified.

We made decisions in fontification, like `dynamic` is now fontified as a type, since for example it can appear in a parameterized type. We leave `var` highlighted as a keyword.

Fontification of numbers and hex numbers as constants, now has a regex that should match what ECMA 408 specifies. We chose not to fontify the unary operator `-` preceding numbers.

Fontification of functions seems relatively straightforward.

Fontification of variables is more difficult. 

The first of two commits for these, fontifies whenever an appropriate lower camel case identifier is appropriately preceded by `final`, `const`, `var`, or a type.

The second of these two commits handles the identifiers that follow, like `b` and `c`, in `var a, b, c;`.

I noticed in the `Known bugs` section at top of source file, that we should also highlight undeclared formal parameters. This makes sense, this will always still be the first place a variable will appear in a scope, if I'm using the term "scope" in a way that makes sense. Maybe this won't be too hard, we could use `font-lock`'s `MATCHER` and `ANCHORED-MATCHER`, several times, to first fontify all positional formal parameters, then fontify named and optional formal parameters. Or something similar. But maybe fontification can be considered usable for now.

Another issue in fontification, we might be able to fix multiline strings (and unescaped quote symbols, as described in issue https://github.com/nex3/dart-mode/issues/31) and raw strings, and perhaps other comment delimiters.