### PR TITLE
Use dart-sdk-path to find dartfmt.

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -1726,10 +1726,11 @@ inside a `before-save-hook'."
 This can be customized by setting `dart-formatter-command-override'."
   (or dart-formatter-command-override
       (when dart-sdk-path
-        (file-name-as-directory "bin")
-            (if (memq system-type '(ms-dos windows-nt))
-                "dartfmt.exe"
-              "dartfmt"))))
+        (concat dart-sdk-path
+                (file-name-as-directory "bin")
+                (if (memq system-type '(ms-dos windows-nt))
+                    "dartfmt.exe"
+                  "dartfmt")))))
 
 (defvar dart--formatter-compilation-regexp
   '("^line \\([0-9]+\\), column \\([0-9]+\\) of \\([^ \n]+\\):" 3 1 2)


### PR DESCRIPTION
The `dart-formatter-command` was not using the `dart-sdk-path` variable to find `dartfmt`. This commit fixes that.