### PR TITLE
Use `run-mode-hooks` to trigger extra major-mode hooks

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -1880,7 +1880,7 @@ Key bindings:
             (lambda () (when dart-format-on-save (dart-format))))
 
   (run-hooks 'c-mode-common-hook)
-  (run-hooks 'dart-mode-hook)
+  (run-mode-hooks 'dart-mode-hook)
   (c-update-modeline))
 
 (provide 'dart-mode)


### PR DESCRIPTION
Instead of using `define-derived-mode` to declare the `dart-mode`, there is a function to setup the mode manually.

This causes other packages to not be able to detect major mode changes, as the `change-major-mode-after-body-hook` and `after-change-major-mode-hook` are not being triggered.

This PR replaces `run-hooks` with `run-mode-hooks` to trigger the extra hooks when changing a major mode. 

### Similar to:
- https://github.com/syl20bnr/spacemacs/issues/7111
- https://github.com/skeeto/elfeed/pull/214
- Fixes https://github.com/syl20bnr/spacemacs/issues/8333