### PR TITLE
Remove deprecated analysis server option

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -833,8 +833,7 @@ Initializes analysis server support for all `dart-mode' buffers."
           (start-process "dart-analysis-server"
                          "*dart-analysis-server*"
                          (dart-executable-path)
-                         (dart--analysis-server-snapshot-path)
-                         "--no-error-notification")))
+                         (dart--analysis-server-snapshot-path))))
     (set-process-query-on-exit-flag dart-process nil)
     (setq dart--analysis-server
           (dart--analysis-server-create dart-process)))


### PR DESCRIPTION
The option was actually removed in https://github.com/dart-lang/sdk/commit/0f7fc43df5b56d5a50d7a7bfe1e11c33f846f789 and it's causing the server to crash as seen in #35 and potentially also in #69 

