### PR TITLE
test: Build with Eask

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 26.3
+          - 27.2
+          - 28.2
+          - 29.1
+        experimental: [false]
+        include:
+        - os: ubuntu-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: macos-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: windows-latest
+          emacs-version: snapshot
+          experimental: true
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
+
+    - name: Run tests
+      run:
+        make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
           - 27.2
           - 28.2
           - 29.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cask
+.eask
 *.elc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cask
 .eask
+dist/
 *.elc

--- a/Eask
+++ b/Eask
@@ -1,0 +1,22 @@
+(package "dart-mode"
+         "1.0.7"
+         "Major mode for editing Dart files")
+
+(website-url "https://github.com/bradyt/dart-mode")
+(keywords "languages")
+
+(package-file "dart-mode.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source 'gnu)
+(source 'melpa)
+
+(depends-on "emacs" "24.3")
+
+(development
+ (depends-on "ert-runner")
+ (depends-on "faceup")
+ (depends-on "package-lint"))
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ package-lint: build
 	eask lint package
 
 test-setup: build compile
+	eask install-deps --dev
 
 test-font-lock: test-setup
 	eask test ert test/test/test-font-lock.el

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,34 @@
-all: package-lint dart-mode.elc test
+all: package-lint compile test
 
-.cask:
-	cask install
+ci: clean build compile
 
-package-lint: .cask
-	cask emacs -batch -l package-lint.el -f package-lint-batch-and-exit
+build:
+	eask package
+	eask install
 
-dart-mode.elc:
-	emacs -batch -f batch-byte-compile dart-mode.el
+compile:
+	eask compile
 
-test-setup: .cask dart-mode.elc
+package-lint: build
+	eask lint package
+
+test-setup: build compile
 
 test-font-lock: test-setup
-	cask emacs -batch -l dart-mode.elc -l ert -l test/test-font-lock.el -f ert-run-tests-batch-and-exit
+	eask test ert test/test/test-font-lock.el
 
 test-indentation: test-setup
-	cask emacs -batch -l dart-mode.elc -l ert -l test/test-indentation.el -f ert-run-tests-batch-and-exit
+	eask test ert test/test-indentation.el
 
 test: test-font-lock test-indentation
 
 checkdoc:
-	emacs -batch -eval "(when (>= emacs-major-version 25) (checkdoc-file \"dart-mode.el\"))"
+	eask lint checkdoc
 
-clean: clean-cask clean-elc
-
-clean-cask:
-	rm -rf .cask
+clean:
+	eask clean all
 
 clean-elc:
-	rm dart-mode.elc
+	eask clean elc
 
 .PHONY: test

--- a/dart-mode.el
+++ b/dart-mode.el
@@ -1,9 +1,15 @@
 ;;; dart-mode.el --- Major mode for editing Dart files -*- lexical-binding: t; -*-
 
-;; Author: https://github.com/bradyt/dart-mode/issues
-;; URL: https://github.com/bradyt/dart-mode
+;; Copyright (C) 2015-2018  Natalie Weizenbaum
+;; Copyright (C) 2018-2023  Brady Trainor
+;; Copyright (C) 2023  Shen, Jen-Chieh
+
+;; Author: Natalie Weizenbaum <nex342@gmail.com>
+;; Maintainer: Brady Trainor
+;;             Jen-Chieh Shen <jcs090218@gmail.com>
+;; URL: https://github.com/emacsorphanage/dart-mode
 ;; Version: 1.0.7
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "26.3"))
 ;; Keywords: languages
 
 ;; The author is Brady Trainor, but removed from keywords in attempt


### PR DESCRIPTION
Add basic CI.

See the test result in https://github.com/jcs-PR/dart-mode/actions/runs/6216847700?pr=1.

**ATTENTION:** There is an upstream bug in the Emacs windows snapshot. The workflow's failure is expected! We can ignore that for now since I've already added the `experimental` flag.