### PR TITLE
Require dart-mode in ERT tests.

### DIFF
--- a/test/test-font-lock.el
+++ b/test/test-font-lock.el
@@ -1,3 +1,4 @@
+(require 'dart-mode)
 (require 'faceup)
 
 (defvar dart-font-lock-test-dir (faceup-this-file-directory))

--- a/test/test-indentation.el
+++ b/test/test-indentation.el
@@ -1,3 +1,4 @@
+(require 'dart-mode)
 
 (defun dart-ert-test-indentation-of-file (file)
   (with-temp-buffer


### PR DESCRIPTION
* This makes it easier to run ERT tests in environment without eask, such as when preparing package for Debian.