### PR TITLE
Fix obsolescence warning on Emacs >=29 about point-at-bol

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -543,7 +543,7 @@ untyped parameters. For example, in
                                            space)
                                       "super")
                                   ?\()
-                              (point-at-bol))
+                              (line-beginning-position))
           (condition-case nil
               (up-list)
             (scan-error (throw 'result nil)))


### PR DESCRIPTION
* Replaced ‘point-at-bol’ by ‘line-beginning-position’ to prevent the following warning:

    ‘point-at-bol’ is an obsolete function (as of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.

